### PR TITLE
Updated DEMetropolis warnings (#3721)

### DIFF
--- a/pymc3/step_methods/arraystep.py
+++ b/pymc3/step_methods/arraystep.py
@@ -212,8 +212,10 @@ class PopulationArrayStepShared(ArrayStepShared):
         self.this_chain = chain_index
         self.other_chains = [c for c in range(len(population)) if c != chain_index]
         if not len(self.other_chains) > 1:
-            raise ValueError('Population is just {} + {}. This is too small. You should ' \
-                'increase the number of chains.'.format(self.this_chain, self.other_chains))
+            raise ValueError(
+                'Population is just {} + {}. ' \
+                'This is too small and the error should have been raised earlier.'.format(self.this_chain, self.other_chains)
+            )
         return
 
 

--- a/pymc3/step_methods/metropolis.py
+++ b/pymc3/step_methods/metropolis.py
@@ -2,7 +2,6 @@ import numpy as np
 import numpy.random as nr
 import theano
 import scipy.linalg
-import warnings
 
 from ..distributions import draw_values
 from .arraystep import ArrayStepShared, PopulationArrayStepShared, ArrayStep, metrop_select, Competence
@@ -537,8 +536,6 @@ class DEMetropolis(PopulationArrayStepShared):
 
     def __init__(self, vars=None, S=None, proposal_dist=None, lamb=None, scaling=0.001,
                  tune=True, tune_interval=100, model=None, mode=None, **kwargs):
-        warnings.warn('Population based sampling methods such as DEMetropolis are experimental.' \
-            ' Use carefully and be extra critical about their results!')
 
         model = pm.modelcontext(model)
 

--- a/pymc3/tests/test_step.py
+++ b/pymc3/tests/test_step.py
@@ -702,8 +702,21 @@ class TestPopulationSamplers:
             for stepper in TestPopulationSamplers.steppers:
                 step = stepper()
                 with pytest.raises(ValueError):
-                    trace = sample(draws=100, chains=1, step=step)
-                trace = sample(draws=100, chains=4, step=step)
+                    sample(draws=10, tune=10, chains=1, cores=1, step=step)
+                # don't parallelize to make test faster
+                sample(draws=10, tune=10, chains=4, cores=1, step=step)
+        pass
+
+    def test_demcmc_warning_on_small_populations(self):
+        """Test that a warning is raised when n_chains <= n_dims"""
+        with Model() as model:
+            Normal("n", mu=0, sigma=1, shape=(2,3))
+            with pytest.warns(UserWarning) as record:
+                sample(
+                    draws=5, tune=5, chains=6, step=DEMetropolis(),
+                    # make tests faster by not parallelizing; disable convergence warning
+                    cores=1, compute_convergence_checks=False
+                )
         pass
 
     def test_nonparallelized_chains_are_random(self):


### PR DESCRIPTION
* remove DEMetropolis warning
closes #3718

* test for warning about too few chains (#3719)
+ accelerate existing test by running fewer iterations non-parallelized

* warn when DE-MCMC is used with too few chains
closes #3719

* fail faster on too small populations
+ keep old check for added safety