### PR TITLE
Fix simple typo: varibles -> variables (#3803)

### DIFF
--- a/pymc3/tests/test_examples.py
+++ b/pymc3/tests/test_examples.py
@@ -179,7 +179,7 @@ class TestDisasterModel(SeededTest):
         with model:
             # Initial values for stochastic nodes
             start = {'early_mean': 2., 'late_mean': 3.}
-            # Use slice sampler for means (other varibles auto-selected)
+            # Use slice sampler for means (other variables auto-selected)
             step = pm.Slice([model.early_mean_log__, model.late_mean_log__])
             tr = pm.sample(500, tune=50, start=start, step=step, chains=2)
             pm.summary(tr)
@@ -189,7 +189,7 @@ class TestDisasterModel(SeededTest):
         with model:
             # Initial values for stochastic nodes
             start = {'early_mean': 2., 'late_mean': 3.}
-            # Use slice sampler for means (other varibles auto-selected)
+            # Use slice sampler for means (other variables auto-selected)
             step = pm.Slice([model.early_mean_log__, model.late_mean_log__])
             tr = pm.sample(500, tune=50, start=start, step=step, chains=2)
             pm.summary(tr)


### PR DESCRIPTION
Closes #3802