### PR TITLE
Fix links to Pymc3 Jupyter Notebook Style Guide (#4486)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ tools:
   $ pytest --cov=pymc3 pymc3/tests/<name of test>.py
   ```
 
-* No `pre-commit` errors: see the [Python code style](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style) and [Jupyter Notebook style](https://github.com/pymc-devs/pymc3/wiki/PyMC's-Jupyter-Notebook-Style) page from our Wiki on how to install and run it.
+* No `pre-commit` errors: see the [Python code style](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style) and [Jupyter Notebook style](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Jupyter-Notebook-Style-Guide) page from our Wiki on how to install and run it.
 
 ## Developing in Docker
 
@@ -148,7 +148,7 @@ docker exec -it pymc3 jupyter notebook list
 We have configured a pre-commit hook that checks for `black`-compliant code style.
 We encourage you to configure the pre-commit hook as described in the [PyMC3 Python Code Style Wiki Page](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style), because it will automatically enforce the code style on your commits.
 
-Similarly, consult the [PyMC's Jupyter Notebook Style](https://github.com/pymc-devs/pymc3/wiki/PyMC's-Jupyter-Notebook-Style) guides for notebooks.
+Similarly, consult the [PyMC's Jupyter Notebook Style](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Jupyter-Notebook-Style-Guide) guides for notebooks.
 
 For documentation strings, we *prefer* [numpy style](https://numpydoc.readthedocs.io/en/latest/format.html) to comply with the style that predominates in our upstream dependencies.
 


### PR DESCRIPTION
Closes #4485


**Thank your for opening a PR!**

Depending on what your PR does, here are a few things you might want to address in the description:
+ [ ] what are the (breaking) changes that this PR makes?
+ [ ] important background, or details about the implementation
+ [ ] are the changes—especially new features—covered by tests and docstrings?
+ [ ] [linting/style checks have been run](https://github.com/pymc-devs/pymc3/wiki/PyMC3-Python-Code-Style)
+ [ ] [consider adding/updating relevant example notebooks](https://github.com/pymc-devs/pymc-examples)
+ [ ] right before it's ready to merge, mention the PR in the RELEASE-NOTES.md
